### PR TITLE
fix: fix plain-object detection for proxy-backed values

### DIFF
--- a/.changeset/late-dodos-beg.md
+++ b/.changeset/late-dodos-beg.md
@@ -1,0 +1,5 @@
+---
+'@birchill/json-equalish': patch
+---
+
+Fix plain-object detection for proxy-backed values

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -83,6 +83,23 @@ describe('jsonEqualish', () => {
     }
   });
 
+  it('should not rely on constructor identity when checking plain objects', () => {
+    const proxy = new Proxy(
+      { a: 123 },
+      {
+        get(target, property, receiver) {
+          if (property === 'constructor') {
+            return function CustomObject() {};
+          }
+
+          return Reflect.get(target, property, receiver);
+        },
+      }
+    );
+
+    expect(jsonEqualish(proxy, { a: 123 })).toBe(true);
+  });
+
   it('should compare objects with a null prototype', () => {
     const objA = Object.create(null);
     objA.a = 123;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,11 +35,9 @@ function objEquiv(a: any, b: any) {
     return false;
   }
 
-  // We only deal with POD at the moment.
-  if (
-    (a.constructor && a.constructor !== Object && a.constructor !== Array) ||
-    (b.constructor && b.constructor !== Object && b.constructor !== Array)
-  ) {
+  // We only deal with POD at the moment. Use the prototype rather than reading
+  // the constructor property since proxies can expose that differently.
+  if (!isPlainObjectOrArray(a) || !isPlainObjectOrArray(b)) {
     throw new Error('Trying to compare something fancy');
   }
 
@@ -71,4 +69,13 @@ function objEquiv(a: any, b: any) {
 
 function definedKeys(a: any) {
   return Object.keys(a).filter((key) => typeof a[key] !== 'undefined');
+}
+
+function isPlainObjectOrArray(value: any) {
+  if (Array.isArray(value)) {
+    return true;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }


### PR DESCRIPTION
No longer rely on reading the constructor property to decide whether a
value is a plain object or array. Some proxy-backed plain objects,
including Immer drafts, can expose constructor with a different identity
even though their prototype is still Object.prototype, which would
otherwise case `jsonEqualish` to throw.

The plain-data guard now uses `Array.isArray()` and
`Object.getPrototypeOf()` instead, preserving support for arrays,
regular objects, and null-prototype objects while avoiding false
rejections for proxy-backed plain objects.
